### PR TITLE
Add: missing <memory> header.

### DIFF
--- a/CppPSO.h
+++ b/CppPSO.h
@@ -2,6 +2,7 @@
 #include <functional>
 #include <vector>
 #include <random>
+#include <memory>
 
 
 namespace CppPSO {


### PR DESCRIPTION
std::shared_ptr is used at line 67.